### PR TITLE
feat: allowing decorators to continue on client failures

### DIFF
--- a/lib/CacheManager.ts
+++ b/lib/CacheManager.ts
@@ -5,6 +5,7 @@ export default class CacheManager {
   public options: CacheManagerOptions = {
     excludeContext: true,
     ttlSeconds: 0,
+    debug: false,
   };
   
   public setClient(client: CacheClient): void {

--- a/lib/decorators/CacheClear.ts
+++ b/lib/decorators/CacheClear.ts
@@ -39,7 +39,14 @@ export function CacheClear(options?: CacheClearOptions) {
         const result = await descriptor.value!.apply(this, args);
 
         // Delete the requested value from cache
-        await client.del(finalKey);
+        try {
+          await client.del(finalKey);
+        } catch (err) {
+          if (cacheManager.options.debug) {
+            console.warn(`type-cacheable CacheClear failure due to client error: ${err.message}`);
+          }
+        }
+
         return result;
       },
     };

--- a/lib/errors/MissingClientError.ts
+++ b/lib/errors/MissingClientError.ts
@@ -1,5 +1,5 @@
 export class MissingClientError extends Error {
   constructor(propertyKey: string) {
-    super(`Missing cache client for ${propertyKey}`);
+    super(`type-cacheable: missing cache client. Please add one or remove the @Cacheable or @CacheClear decorator from ${propertyKey}, as it is not being used.`);
   }
 }

--- a/lib/interfaces/CacheManagerOptions.ts
+++ b/lib/interfaces/CacheManagerOptions.ts
@@ -1,4 +1,5 @@
 export interface CacheManagerOptions {
   excludeContext?: boolean;
   ttlSeconds?: number;
+  debug?: boolean;
 }


### PR DESCRIPTION
This will address #30 and allow methods to run when the underlying cache clients fail.