### PR TITLE
test: add test coverage for failing cache client

### DIFF
--- a/test/decorators/CacheClear.test.ts
+++ b/test/decorators/CacheClear.test.ts
@@ -30,6 +30,47 @@ describe('CacheClear Decorator Tests', () => {
     }
   });
 
+  it('should not throw an error if the client fails', async () => {
+    class TestClass {
+      public aProp: string = 'aVal!';
+
+      static setCacheKey = (args: any[]) => args[0];
+
+      @Cacheable({ cacheKey: TestClass.setCacheKey })
+      public async getProp(id: string): Promise<any> {
+        return this.aProp;
+      }
+
+      @CacheClear({ cacheKey: TestClass.setCacheKey })
+      public async setProp(id: string, value: string): Promise<void> {
+        this.aProp = value;
+      }
+    }
+
+    cacheManager.client!.get = async (cacheKey: string) => {
+      throw new Error('client failure');
+    };
+
+    cacheManager.client!.set = async (cacheKey: string, value: any) => {
+      throw new Error('client failure');
+    };
+
+    cacheManager.client!.del = async (cacheKey: string) => {
+      throw new Error('client failure');
+    };
+
+    const testInstance = new TestClass();
+    let err;
+    try {
+      await testInstance.getProp('1');
+      await testInstance.setProp('1', 'anotherValue!');
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeFalsy();
+  });
+
   it('should clear a cached key when a CacheClear-decorated method is called', async () => {
     class TestClass {
       public aProp: string = 'aVal!';

--- a/test/decorators/Cacheable.test.ts
+++ b/test/decorators/Cacheable.test.ts
@@ -30,6 +30,35 @@ describe('Cacheable Decorator Tests', () => {
     }
   });
 
+  it('should not throw an error if the client fails', async () => {
+    class TestClass {
+      public aProp: string = 'aVal!';
+
+      @Cacheable()
+      public async hello(): Promise<any> {
+        return 'world';
+      }
+    }
+
+    cacheManager.client!.get = async (cacheKey: string) => {
+      throw new Error('client failure');
+    };
+
+    cacheManager.client!.set = async (cacheKey: string, value: any) => {
+      throw new Error('client failure');
+    };
+
+    const testInstance = new TestClass();
+    let err;
+    try {
+      await testInstance.hello();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeFalsy();
+  });
+
   it('should attempt to get and set the cache on an initial call to a decorated method, only get on subsequent calls', async () => {
     class TestClass {
       public aProp: string = 'aVal!';


### PR DESCRIPTION
This adds test coverage for the case when the cache client fails during a set, get, or delete operation.