### PR TITLE
Defaulting to noop for caching rather than throwing

### DIFF
--- a/lib/decorators/CacheClear.ts
+++ b/lib/decorators/CacheClear.ts
@@ -1,6 +1,5 @@
 import { CacheClearOptions } from '../interfaces';
 import { getFinalKey, determineOp } from '../util';
-import { MissingClientError } from '../errors';
 import cacheManager from '../index';
 
 /**
@@ -27,7 +26,11 @@ export function CacheClear(options?: CacheClearOptions) {
           }
 
           // A caching client must exist if not set to noop, otherwise this library is doing nothing.
-          throw new MissingClientError(propertyKey);
+          if (cacheManager.options.debug) {
+            console.warn('type-cacheable @CacheClear was not set up with a caching client. Without a client, type-cacheable is not serving a purpose.');
+          }
+
+          return descriptor.value!.apply(this, args);
         }
 
         const contextToUse = !cacheManager.options.excludeContext

--- a/lib/decorators/Cacheable.ts
+++ b/lib/decorators/Cacheable.ts
@@ -1,6 +1,5 @@
 import { CacheOptions } from '../interfaces';
 import { determineOp, getFinalKey, getTTL } from '../util';
-import { MissingClientError } from '../errors';
 import cacheManager from '../index';
 
 /**
@@ -29,7 +28,11 @@ export function Cacheable(options?: CacheOptions) {
           }
 
           // A caching client must exist if not set to noop, otherwise this library is doing nothing.
-          throw new MissingClientError(propertyKey);
+          if (cacheManager.options.debug) {
+            console.warn('type-cacheable @Cacheable was not set up with a caching client. Without a client, type-cacheable is not serving a purpose.');
+          }
+
+          return descriptor.value!.apply(this, args);
         }
 
         const contextToUse = !cacheManager.options.excludeContext

--- a/lib/errors/MissingClientError.ts
+++ b/lib/errors/MissingClientError.ts
@@ -1,5 +1,0 @@
-export class MissingClientError extends Error {
-  constructor(propertyKey: string) {
-    super(`type-cacheable: missing cache client. Please add one or remove the @Cacheable or @CacheClear decorator from ${propertyKey}, as it is not being used.`);
-  }
-}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,1 +1,0 @@
-export { MissingClientError } from './MissingClientError';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,6 @@
 import CacheManager from './CacheManager';
 export * from './adapters';
 export * from './decorators';
-export * from './errors';
 export * from './interfaces';
 export * from './util';
 

--- a/test/decorators/CacheClear.test.ts
+++ b/test/decorators/CacheClear.test.ts
@@ -1,6 +1,5 @@
 import * as Redis from 'redis';
 import { Cacheable, CacheClear } from '../../lib/decorators';
-import { MissingClientError } from '../../lib/errors';
 import cacheManager from '../../lib';
 import { useRedisAdapter } from '../../lib/util/useAdapter';
 
@@ -13,21 +12,6 @@ describe('CacheClear Decorator Tests', () => {
 
   beforeEach(() => {
     useRedisAdapter(client);
-  });
-
-  it('should throw a MissingClientError if no cache manager was set up', () => {
-    cacheManager.client = null;
-
-    try {
-      class FailClass {
-        @CacheClear()
-        public async hello(): Promise<any> {
-          return 'world';
-        };
-      }
-    } catch (err) {
-      expect(err).toBeInstanceOf(MissingClientError);
-    }
   });
 
   it('should not throw an error if the client fails', async () => {

--- a/test/decorators/Cacheable.test.ts
+++ b/test/decorators/Cacheable.test.ts
@@ -1,6 +1,5 @@
 import * as Redis from 'redis';
 import { Cacheable } from '../../lib/decorators';
-import { MissingClientError } from '../../lib/errors';
 import cacheManager from '../../lib';
 import { useRedisAdapter } from '../../lib/util/useAdapter';
 
@@ -13,21 +12,6 @@ describe('Cacheable Decorator Tests', () => {
 
   beforeEach(() => {
     useRedisAdapter(client);
-  });
-
-  it('should throw a MissingClientError if no cache manager was set up', () => {
-    cacheManager.client = null;
-
-    try {
-      class FailClass {
-        @Cacheable()
-        public async hello(): Promise<any> {
-          return 'world';
-        };
-      }
-    } catch (err) {
-      expect(err).toBeInstanceOf(MissingClientError);
-    }
   });
 
   it('should not throw an error if the client fails', async () => {


### PR DESCRIPTION
Instead of throwing a missing client error, we'll log a warning if there's a missing client and we're in debug mode, otherwise just run the decorated function.