### PR TITLE
fix: not failing when the redis client refuses connections

### DIFF
--- a/lib/adapters/RedisAdapter.ts
+++ b/lib/adapters/RedisAdapter.ts
@@ -27,7 +27,10 @@ export class RedisAdapter implements CacheClient {
 
   constructor(redisClient: RedisClient) {
     this.redisClient = redisClient;
-    this.clientReady = false;
+    this.clientReady = this.redisClient.ping();
+    this.redisClient.on('ready', () => {
+      this.clientReady = true;
+    });
     this.redisClient.on('error', () => {
       this.clientReady = false;
     });
@@ -52,12 +55,12 @@ export class RedisAdapter implements CacheClient {
     }
 
     return this.clientReady;
-  }
+  };
 
   // Redis doesn't have a standard TTL, it's at a per-key basis
   public getClientTTL(): number {
     return 0;
-  }
+  };
 
   public async get(cacheKey: string): Promise<any> {
     const isReady = this.checkIfReady();
@@ -77,7 +80,7 @@ export class RedisAdapter implements CacheClient {
 
         return usableResult;
       });
-    }
+    };
 
     throw new Error('Redis client is not accepting connections.');
   };

--- a/lib/adapters/RedisAdapter.ts
+++ b/lib/adapters/RedisAdapter.ts
@@ -11,20 +11,48 @@ export class RedisAdapter implements CacheClient {
     }, [] as string[]);
 
   static responseCallback = (resolve: Function, reject: Function): Callback<any> =>
-  (err: any, response: any) => {
-    if (err) {
-      reject(err);
-    } else {
-      resolve(response);
-    }
-  };
+    (err: any, response: any) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(response);
+      }
+    };
 
   // The node_redis client
   private redisClient: RedisClient;
 
+  private clientReady: boolean = false;
+  private isPingingClient: boolean = false;
+
   constructor(redisClient: RedisClient) {
     this.redisClient = redisClient;
+    this.clientReady = false;
+    this.redisClient.on('error', () => {
+      this.clientReady = false;
+    });
+
+    this.checkIfReady();
   };
+
+  /**
+   * checkIfReady will return the last received ready status of the client.
+   * If the client isn't ready, it will ping the redis client to check if it's ready
+   * yet. This isn't a perfect solution, because we're not waiting for the response (so as to
+   * not add latency to the underlying method calls). I believe it's a reasonable trade-off to
+   * have a potential cache miss rather than add latency to all decorated method calls.
+   */
+  private checkIfReady(): boolean {
+    if (!this.clientReady && !this.isPingingClient) {
+      this.isPingingClient = true;
+      this.redisClient.ping(() => {
+        this.clientReady = true;
+        this.isPingingClient = false;
+      });
+    }
+
+    return this.clientReady;
+  }
 
   // Redis doesn't have a standard TTL, it's at a per-key basis
   public getClientTTL(): number {
@@ -32,20 +60,26 @@ export class RedisAdapter implements CacheClient {
   }
 
   public async get(cacheKey: string): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (cacheKey.includes(':')) {
-        this.redisClient.hgetall(cacheKey, RedisAdapter.responseCallback(resolve, reject));
-      } else {
-        this.redisClient.get(cacheKey, RedisAdapter.responseCallback(resolve, reject));
-      }
-    }).then((result: any) => {
-      const usableResult = parseIfRequired(result);
-      if (usableResult && typeof usableResult === 'object' && Object.keys(usableResult).every(key => Number.isInteger(Number(key)))) {
-        return Object.keys(usableResult).map(key => parseIfRequired(usableResult[key]));
-      }
+    const isReady = this.checkIfReady();
 
-      return usableResult;
-    });
+    if (isReady) {
+      return new Promise((resolve, reject) => {
+        if (cacheKey.includes(':')) {
+          this.redisClient.hgetall(cacheKey, RedisAdapter.responseCallback(resolve, reject));
+        } else {
+          this.redisClient.get(cacheKey, RedisAdapter.responseCallback(resolve, reject));
+        }
+      }).then((result: any) => {
+        const usableResult = parseIfRequired(result);
+        if (usableResult && typeof usableResult === 'object' && Object.keys(usableResult).every(key => Number.isInteger(Number(key)))) {
+          return Object.keys(usableResult).map(key => parseIfRequired(usableResult[key]));
+        }
+
+        return usableResult;
+      });
+    }
+
+    throw new Error('Redis client is not accepting connections.');
   };
 
   /**
@@ -58,36 +92,48 @@ export class RedisAdapter implements CacheClient {
    * @returns {Promise}
    */
   public async set(cacheKey: string, value: any, ttl?: number): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (cacheKey.includes(':') && typeof value === 'object') {
-        const args = RedisAdapter.buildSetArgumentsFromObject(value);
+    const isReady = this.checkIfReady();
 
-        this.redisClient.hmset(cacheKey, args, (err, result) => {
-          if (!err) {
-            // hmset doesn't add expiration by default, so we have to implement that here if ttl is given
-            if (ttl) {
-              this.redisClient.expire(cacheKey, ttl, RedisAdapter.responseCallback(resolve, reject));
-              return;
+    if (isReady) {
+      return new Promise((resolve, reject) => {
+        if (cacheKey.includes(':') && typeof value === 'object') {
+          const args = RedisAdapter.buildSetArgumentsFromObject(value);
+
+          this.redisClient.hmset(cacheKey, args, (err, result) => {
+            if (!err) {
+              // hmset doesn't add expiration by default, so we have to implement that here if ttl is given
+              if (ttl) {
+                this.redisClient.expire(cacheKey, ttl, RedisAdapter.responseCallback(resolve, reject));
+                return;
+              }
             }
-          }
 
-          RedisAdapter.responseCallback(resolve, reject)(err, result);
-        });
-      } else {
-        const usableValue = typeof value === 'string' ? value : JSON.stringify(value);
-
-        if (ttl) {
-          this.redisClient.set(cacheKey, usableValue, 'EX', ttl, RedisAdapter.responseCallback(resolve, reject));
+            RedisAdapter.responseCallback(resolve, reject)(err, result);
+          });
         } else {
-          this.redisClient.set(cacheKey, usableValue, RedisAdapter.responseCallback(resolve, reject));
+          const usableValue = typeof value === 'string' ? value : JSON.stringify(value);
+
+          if (ttl) {
+            this.redisClient.set(cacheKey, usableValue, 'EX', ttl, RedisAdapter.responseCallback(resolve, reject));
+          } else {
+            this.redisClient.set(cacheKey, usableValue, RedisAdapter.responseCallback(resolve, reject));
+          }
         }
-      }
-    })
+      });
+    }
+
+    throw new Error('Redis client is not accepting connections.');
   };
 
   public async del(cacheKey: string): Promise<any> {
-    return new Promise((resolve, reject) => {
-      this.redisClient.del(cacheKey, RedisAdapter.responseCallback(resolve, reject));
-    });
+    const isReady = this.checkIfReady();
+
+    if (isReady) {
+      return new Promise((resolve, reject) => {
+        this.redisClient.del(cacheKey, RedisAdapter.responseCallback(resolve, reject));
+      });
+    }
+
+    throw new Error('Redis client is not accepting connections.');
   };
 }

--- a/test/adapters/RedisAdapter.test.ts
+++ b/test/adapters/RedisAdapter.test.ts
@@ -11,8 +11,16 @@ const objectValue = { myKeyOne: 'myValOne' };
 const arrayValue = ['element1', 2, { complex: 'element' }];
 
 describe('RedisAdapter Tests', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     client = Redis.createClient();
+
+    // Wait until the connection is ready before passing the client to the adapter.
+    await new Promise(resolve => {
+      client.on('ready', () => {
+        resolve();
+      });
+    });
+
     redisAdapter = new RedisAdapter(client);
   });
 


### PR DESCRIPTION
This _should_ fix #30. If the redis connection hasn't proven to be ready, we'll try to ping it but allow the decorated method to still run without hitting the cache.