### PR TITLE
Replace external md5 with crypto

### DIFF
--- a/lib/util/getCacheKey.ts
+++ b/lib/util/getCacheKey.ts
@@ -1,4 +1,4 @@
-import * as md5 from 'md5';
+import { createHash } from 'crypto';
 import * as serialize from 'serialize-javascript';
 import { CacheKeyBuilder } from '../interfaces';
 
@@ -54,8 +54,7 @@ export const getCacheKey = (
   };
 
   const serializedKey = serialize(callMap);
-  const hashedKey = md5(serializedKey);
-  return hashedKey;
+  return createHash('md5').update(serializedKey).digest('hex');
 };
 
 export const getFinalKey = (

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "homepage": "https://github.com/joshuaslate/type-cacheable#readme",
   "devDependencies": {
     "@types/jest": "^25.1.0",
-    "@types/md5": "^2.1.33",
     "@types/node": "^13.7.0",
     "@types/serialize-javascript": "^1.5.0",
     "ioredis": "^4.14.1",
@@ -53,7 +52,6 @@
     "@types/ioredis": "^4.14.4",
     "@types/node-cache": "^4.1.3",
     "@types/redis": "^2.8.13",
-    "md5": "^2.2.1",
     "serialize-javascript": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -892,10 +892,6 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
-
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1026,10 +1022,6 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cssom@^0.4.1:
   version "0.4.4"
@@ -1621,7 +1613,7 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
-is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -2334,15 +2326,6 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
-
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
-  integrity sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi! md5 dependency can be removed. Standard `crypto` module  can be used instead of it.
And crypto is slightly faster.