### PR TITLE
feat: Add builder for cache strategy

### DIFF
--- a/packages/core/lib/interfaces/CacheManagerOptions.ts
+++ b/packages/core/lib/interfaces/CacheManagerOptions.ts
@@ -1,8 +1,9 @@
 import { CacheStrategy } from './CacheStrategy';
+import { CacheStrategyBuilder } from './CacheStrategyBuilder';
 
 export interface CacheManagerOptions {
   excludeContext?: boolean;
   ttlSeconds?: number;
   debug?: boolean;
-  strategy?: CacheStrategy;
+  strategy?: CacheStrategy | CacheStrategyBuilder;
 }

--- a/packages/core/lib/interfaces/CacheOptions.ts
+++ b/packages/core/lib/interfaces/CacheOptions.ts
@@ -1,4 +1,11 @@
-import { CacheKeyBuilder, CacheClient, NoOpDeterminer, TTLBuilder, CacheStrategy } from './';
+import {
+  CacheKeyBuilder,
+  CacheClient,
+  NoOpDeterminer,
+  TTLBuilder,
+  CacheStrategy,
+} from './';
+import { CacheStrategyBuilder } from './CacheStrategyBuilder';
 
 export interface CacheOptions {
   cacheKey?: string | CacheKeyBuilder;
@@ -6,5 +13,5 @@ export interface CacheOptions {
   client?: CacheClient;
   noop?: boolean | NoOpDeterminer;
   ttlSeconds?: number | TTLBuilder;
-  strategy?: CacheStrategy;
+  strategy?: CacheStrategy | CacheStrategyBuilder;
 }

--- a/packages/core/lib/interfaces/CacheStrategyBuilder.ts
+++ b/packages/core/lib/interfaces/CacheStrategyBuilder.ts
@@ -1,0 +1,5 @@
+import { CacheStrategy } from './CacheStrategy';
+
+export interface CacheStrategyBuilder {
+  (args: any[], context?: any): CacheStrategy;
+}

--- a/packages/core/lib/interfaces/index.ts
+++ b/packages/core/lib/interfaces/index.ts
@@ -6,4 +6,5 @@ export { CacheManagerOptions } from './CacheManagerOptions';
 export { CacheStrategy } from './CacheStrategy';
 export { CacheStrategyContext } from './CacheStrategyContext';
 export { NoOpDeterminer } from './NoOpDeterminer';
+export { CacheStrategyBuilder as StrategyBuilder } from './CacheStrategyBuilder';
 export { TTLBuilder } from './TTLBuilder';

--- a/packages/core/lib/util/getCacheStrategy.ts
+++ b/packages/core/lib/util/getCacheStrategy.ts
@@ -1,0 +1,23 @@
+import { CacheStrategyBuilder } from '../interfaces/CacheStrategyBuilder';
+import { CacheStrategy } from '../interfaces';
+
+/**
+ * getCacheStrategy - This is the strategy to use for caching data, or a function to extract it
+ *
+ * @param passedInCacheStrategy The desired cache strategy, or function to build the cache Strategy based on arguments/context
+ * @param args        The arguments the decorated method was called with
+ * @param context     The instance whose method is being called
+ *
+ * @returns {String}
+ */
+export const getCacheStrategy = (
+  passedInCacheStrategy: CacheStrategy | CacheStrategyBuilder,
+  args: any[],
+  context?: any
+): CacheStrategy => {
+  // If the user passed in a cacheKey, use that. If it's a string/number, use it directly.
+  // In the case of a function
+  return passedInCacheStrategy instanceof Function
+    ? passedInCacheStrategy(args, context)
+    : passedInCacheStrategy;
+};

--- a/packages/core/lib/util/index.ts
+++ b/packages/core/lib/util/index.ts
@@ -1,5 +1,6 @@
 export { determineOp } from './determineOp';
 export { extractKey, getCacheKey, getFinalKey } from './getCacheKey';
+export { getCacheStrategy } from './getCacheStrategy';
 export { getTTL } from './getTTL';
 export { parseIfRequired } from './parseIfRequired';
 export { withTimeout } from './withTimeout';

--- a/packages/core/test/util/getCacheStrategy.test.ts
+++ b/packages/core/test/util/getCacheStrategy.test.ts
@@ -1,0 +1,26 @@
+import { getCacheStrategy } from '../../lib/util';
+import { DefaultStrategy } from '../../lib/strategies';
+
+const mockArgs: any[] = [
+  1,
+  'two',
+  function () {
+    console.log('this is a test');
+  },
+];
+
+describe('getCacheStrategy Tests', () => {
+  it('should return the strategy, if a strategy is given', () => {
+    const strategy = new DefaultStrategy();
+    expect(getCacheStrategy(strategy, mockArgs)).toBe(strategy);
+  });
+
+  it('should return the value returned by a passed in CacheStrategyBuilder, if a fn is given', () => {
+    const strategy = new DefaultStrategy();
+    expect(
+      getCacheStrategy((args) => {
+        return strategy;
+      }, mockArgs)
+    ).toBe(strategy);
+  });
+});


### PR DESCRIPTION
Provide the option to pass a builder for a strategy to make use of method arguments and context when creating the strategy. A possible use case would be to pass a logger to the constructor of the strategy, which can be used instead of the console for logging.