### PR TITLE
fix: [BREAKING] #204 - redis scan using cursor

### DIFF
--- a/packages/ioredis-adapter/test/IoRedisAdapter.test.ts
+++ b/packages/ioredis-adapter/test/IoRedisAdapter.test.ts
@@ -108,7 +108,7 @@ describe('IoRedisAdapter Tests', () => {
   describe('Keys tests', () => {
     it('should get keys by pattern on a compound (x:y) key', async () => {
       await client.set(compoundKey, simpleValue);
-      const result = await ioRedisAdapter.keys(compoundKey);
+      const result = await ioRedisAdapter.keys(`*${compoundKey}*`);
 
       expect(result).toHaveLength(1);
       expect(result).toContain(compoundKey);
@@ -116,8 +116,7 @@ describe('IoRedisAdapter Tests', () => {
 
     it('should not found keys on a simple key', async () => {
       await client.set(compoundKey, simpleValue);
-
-      const result = await ioRedisAdapter.keys(simpleValue);
+      const result = await ioRedisAdapter.keys(`*${simpleValue}*`);
 
       expect(result).toHaveLength(0);
       expect(result).toBeInstanceOf(Array);

--- a/packages/node-cache-adapter/lib/index.ts
+++ b/packages/node-cache-adapter/lib/index.ts
@@ -43,6 +43,7 @@ export class NodeCacheAdapter implements CacheClient {
     const allKeys = this.nodeCacheClient.keys();
     const regExp = new RegExp(pattern, 'g');
     let matchedKeys = [];
+
     for (let key of allKeys) {
       if (Array.isArray(key.match(regExp))) {
         matchedKeys.push(key);

--- a/packages/redis-adapter/test/RedisAdapter.test.ts
+++ b/packages/redis-adapter/test/RedisAdapter.test.ts
@@ -124,6 +124,28 @@ describe('RedisAdapter Tests', () => {
     });
   });
 
+  describe('Keys tests', () => {
+    it('should get keys by pattern on a compound (x:y) key', (done) => {
+      client.set(compoundKey, simpleValue, async () => {
+        const result = await redisAdapter.keys(`*${compoundKey}*`);
+
+        expect(result).toHaveLength(1);
+        expect(result).toContain(compoundKey);
+        done();
+      });
+    });
+
+    it('should not found keys on a simple key', (done) => {
+      client.set(compoundKey, simpleValue, async () => {
+        const result = await redisAdapter.keys(`*${simpleValue}*`);
+
+        expect(result).toHaveLength(0);
+        expect(result).toBeInstanceOf(Array);
+        done();
+      });
+    });
+  });
+
   describe('integration', () => {
     it('should properly set, and get cached, values with the @Cacheable decorator', async () => {
       const mockGetIdImplementation = jest.fn();


### PR DESCRIPTION
This is to fix #204, using cursor-based scanning for the redis adapters.