### PR TITLE
feat: [#211] - adding support for array of cache keys for CacheClear

### DIFF
--- a/packages/core/lib/interfaces/CacheClearOptions.ts
+++ b/packages/core/lib/interfaces/CacheClearOptions.ts
@@ -1,9 +1,10 @@
 import { CacheKeyBuilder } from './CacheKeyBuilder';
 import { CacheClient } from './CacheClient';
 import { NoOpDeterminer } from './NoOpDeterminer';
+import { CacheKeyDeleteBuilder } from './CacheKeyDeleteBuilder';
 
 export interface CacheClearOptions {
-  cacheKey?: string | CacheKeyBuilder;
+  cacheKey?: string | string[] | CacheKeyDeleteBuilder;
   hashKey?: string | CacheKeyBuilder;
   client?: CacheClient;
   fallbackClient?: CacheClient;

--- a/packages/core/lib/interfaces/CacheKeyDeleteBuilder.ts
+++ b/packages/core/lib/interfaces/CacheKeyDeleteBuilder.ts
@@ -1,0 +1,3 @@
+export interface CacheKeyDeleteBuilder {
+  (args: any[], context?: any): string | string[];
+}

--- a/packages/core/lib/interfaces/index.ts
+++ b/packages/core/lib/interfaces/index.ts
@@ -1,4 +1,5 @@
 export { CacheKeyBuilder } from './CacheKeyBuilder';
+export { CacheKeyDeleteBuilder } from './CacheKeyDeleteBuilder';
 export { CacheClient } from './CacheClient';
 export { CacheOptions } from './CacheOptions';
 export { CacheClearOptions } from './CacheClearOptions';


### PR DESCRIPTION
This adds support for passing an array of cache keys to clear to the `CacheClear` decorator.