### PR TITLE
Fix endless loop in keys()

### DIFF
--- a/packages/ioredis-adapter/lib/index.ts
+++ b/packages/ioredis-adapter/lib/index.ts
@@ -78,7 +78,7 @@ export class IoRedisAdapter implements CacheClient {
       if (result) {
         // array exists at index 1 from SCAN command, cursor is at 0
         keys = [...keys, ...result[1]];
-        cursor = Number(result[0]) !== cursor ? Number(result[0]) : null;
+        cursor = Number(result[0]) !== 0 ? Number(result[0]) : null;
       } else {
         cursor = null;
       }

--- a/packages/redis-adapter/lib/index.ts
+++ b/packages/redis-adapter/lib/index.ts
@@ -263,7 +263,7 @@ export class RedisAdapter implements CacheClient {
 
         if (result) {
           // array exists at index 1 from SCAN command, cursor is at 0
-          cursor = cursor !== result[0] ? result[0] : null;
+          cursor = result[0] !== 0 ? result[0] : null;
           keys = [...keys, ...result[1]];
         } else {
           cursor = null;


### PR DESCRIPTION
This is related to https://github.com/joshuaslate/type-cacheable/issues/204 and fixes incorrect cursor value usage in the loop