### PR TITLE
#272 - making @type-cacheable/core a peerDep

### DIFF
--- a/packages/ioredis-adapter/package.json
+++ b/packages/ioredis-adapter/package.json
@@ -40,13 +40,14 @@
     "ioredis": "^4.14.1",
     "jest": "^26.3.0",
     "ts-jest": "^26.2.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "@type-cacheable/core": "^8.0.5"
   },
   "peerDependencies": {
+    "@type-cacheable/core": "^8.0.5",
     "ioredis": "^4.14.1"
   },
   "dependencies": {
-    "@type-cacheable/core": "^8.0.5",
     "compare-versions": "^3.6.0"
   },
   "gitHead": "fc819565536432e484c60432a6c184ba700b3c92"

--- a/packages/lru-cache-adapter/package.json
+++ b/packages/lru-cache-adapter/package.json
@@ -38,13 +38,13 @@
     "@types/jest": "^26.0.0",
     "@types/lru-cache": "^5.1.0",
     "lru-cache": "^6.0.0",
-    "typescript": "^4.0.2"
-  },
-  "peerDependencies": {
-    "lru-cache": "^6.0.0"
-  },
-  "dependencies": {
+    "typescript": "^4.0.2",
     "@type-cacheable/core": "^8.0.5"
   },
+  "peerDependencies": {
+    "@type-cacheable/core": "^8.0.5",
+    "lru-cache": "^6.0.0"
+  },
+  "dependencies": {},
   "gitHead": "fc819565536432e484c60432a6c184ba700b3c92"
 }

--- a/packages/node-cache-adapter/package.json
+++ b/packages/node-cache-adapter/package.json
@@ -39,13 +39,13 @@
     "jest": "^26.3.0",
     "node-cache": "^5.0.0",
     "ts-jest": "^26.2.0",
-    "typescript": "^4.0.2"
-  },
-  "peerDependencies": {
-    "node-cache": "^5.0.0"
-  },
-  "dependencies": {
+    "typescript": "^4.0.2",
     "@type-cacheable/core": "^8.0.5"
   },
+  "peerDependencies": {
+    "@type-cacheable/core": "^8.0.5",
+    "node-cache": "^5.0.0"
+  },
+  "dependencies": {},
   "gitHead": "fc819565536432e484c60432a6c184ba700b3c92"
 }

--- a/packages/redis-adapter/package.json
+++ b/packages/redis-adapter/package.json
@@ -40,13 +40,14 @@
     "jest": "^26.3.0",
     "redis": "^3.0.2",
     "ts-jest": "^26.2.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "@type-cacheable/core": "^8.0.5"
   },
   "peerDependencies": {
+    "@type-cacheable/core": "^8.0.5",
     "redis": "^3.0.2"
   },
   "dependencies": {
-    "@type-cacheable/core": "^8.0.5",
     "compare-versions": "^3.6.0"
   },
   "gitHead": "fc819565536432e484c60432a6c184ba700b3c92"


### PR DESCRIPTION
Making `@type-cacheable/core` a peerDep instead of dependency.