### PR TITLE
useAdapter should return adapter client for Cacheable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ import * as Redis from 'redis';
 import { Cacheable, CacheClear } from '@type-cacheable/core';
 
 const userClient = Redis.createClient();
+const clientAdapter = useAdapter(userClient)
 
 class TestClass {
   private values: any[] = [1, 2, 3, 4, 5];
@@ -99,7 +100,7 @@ class TestClass {
 
   @Cacheable({
     cacheKey: 'users',
-    client: userClient,
+    client: clientAdapter,
     ttlSeconds: 86400,
   })
   public async getUsers(): Promise<any> {
@@ -111,7 +112,7 @@ class TestClass {
   @Cacheable({
     cacheKey: TestClass.setCacheKey,
     hashKey: 'user',
-    client: userClient,
+    client: clientAdapter,
     ttlSeconds: 86400,
   })
   public async getUserById(id: string): Promise<any> {

--- a/packages/ioredis-adapter/README.md
+++ b/packages/ioredis-adapter/README.md
@@ -25,7 +25,7 @@ import * as IoRedis from 'ioredis';
 import { useAdapter } from '@type-cacheable/ioredis-adapter';
 
 const client = new IoRedis();
-useAdapter(client);
+const clientAdapter = useAdapter(client);
 ```
 
 Then you can rely on the `@Cacheable`, `@CacheUpdate`, and `@CacheClear` decorators from `@type-cacheable/core`. [See core documentation](https://github.com/joshuaslate/type-cacheable/tree/main/packages/core)

--- a/packages/ioredis-adapter/lib/index.ts
+++ b/packages/ioredis-adapter/lib/index.ts
@@ -96,7 +96,7 @@ export class IoRedisAdapter implements CacheClient {
   }
 }
 
-export const useAdapter = (client: Redis, asFallback?: boolean): void => {
+export const useAdapter = (client: Redis, asFallback?: boolean): IoRedisAdapter => {
   const ioRedisAdapter = new IoRedisAdapter(client);
 
   if (asFallback) {
@@ -104,4 +104,6 @@ export const useAdapter = (client: Redis, asFallback?: boolean): void => {
   } else {
     cacheManager.setClient(ioRedisAdapter);
   }
+
+  return ioRedisAdapter;
 };

--- a/packages/ioredis-adapter/test/IoRedisAdapter.test.ts
+++ b/packages/ioredis-adapter/test/IoRedisAdapter.test.ts
@@ -1,6 +1,6 @@
 import * as IoRedis from 'ioredis';
 import { Cacheable, CacheClear } from '@type-cacheable/core';
-import { IoRedisAdapter } from '../lib';
+import { IoRedisAdapter, useAdapter } from '../lib';
 
 let client: IoRedis.Redis;
 let ioRedisAdapter: IoRedisAdapter;
@@ -15,8 +15,7 @@ const arrayValue = ['element1IoRedis', 2, { complex: 'elementIoRedis' }];
 describe('IoRedisAdapter Tests', () => {
   beforeAll(async () => {
     client = new IoRedis();
-
-    ioRedisAdapter = new IoRedisAdapter(client);
+    ioRedisAdapter = useAdapter(client);
   });
 
   describe('Setter tests', () => {

--- a/packages/lru-cache-adapter/README.md
+++ b/packages/lru-cache-adapter/README.md
@@ -25,7 +25,7 @@ import * as LRUCache from 'lru-cache';
 import { useAdapter } from '@type-cacheable/lru-cache-adapter';
 
 const client = new LRUCache();
-useAdapter(client);
+const clientAdapter = useAdapter(client);
 ```
 
 Then you can rely on the `@Cacheable`, `@CacheUpdate`, and `@CacheClear` decorators from `@type-cacheable/core`. [See core documentation](https://github.com/joshuaslate/type-cacheable/tree/main/packages/core)

--- a/packages/lru-cache-adapter/lib/index.ts
+++ b/packages/lru-cache-adapter/lib/index.ts
@@ -77,7 +77,7 @@ export class LRUCacheAdapter<T> implements CacheClient {
 export const useAdapter = <T>(
   client: LRUCache<string, T>,
   asFallback?: boolean
-): void => {
+): LRUCacheAdapter<T> => {
   const lruCacheAdapter = new LRUCacheAdapter(client);
 
   if (asFallback) {
@@ -85,4 +85,5 @@ export const useAdapter = <T>(
   } else {
     cacheManager.setClient(lruCacheAdapter);
   }
+  return lruCacheAdapter;
 };

--- a/packages/lru-cache-adapter/test/LRUCacheAdapter.test.ts
+++ b/packages/lru-cache-adapter/test/LRUCacheAdapter.test.ts
@@ -1,12 +1,11 @@
 import * as LRUCache from 'lru-cache';
 import { Cacheable } from '@type-cacheable/core';
-import { LRUCacheAdapter } from '../lib';
+import { LRUCacheAdapter, useAdapter } from '../lib';
 
 let client: LRUCache<string, any>;
 let lruCacheAdapter: LRUCacheAdapter<any>;
 
 const keyName = 'aSimpleLRUCacheKey';
-const keyName_2 = 'aSimpleLRUCacheKey2';
 const compoundKey = 'aCompoundLRUCache:key';
 const simpleValue = 'aSimpleLRUCacheValue';
 const objectValue = { myKeyOneLRUCache: 'myValOneLRUCache' };
@@ -15,8 +14,7 @@ const arrayValue = ['element1LRUCache', 2, { complex: 'elementLRUCache' }];
 describe('LRUCacheAdapter Tests', () => {
   beforeAll(async () => {
     client = new LRUCache();
-
-    lruCacheAdapter = new LRUCacheAdapter(client);
+    lruCacheAdapter = useAdapter(client);
   });
 
   describe('Setter tests', () => {

--- a/packages/node-cache-adapter/README.md
+++ b/packages/node-cache-adapter/README.md
@@ -25,7 +25,7 @@ import * as NodeCache from 'node-cache';
 import { useAdapter } from '@type-cacheable/node-cache-adapter';
 
 const client = new NodeCache();
-useAdapter(client);
+const clientAdapter = useAdapter(client);
 ```
 
 Then you can rely on the `@Cacheable`, `@CacheUpdate`, and `@CacheClear` decorators from `@type-cacheable/core`. [See core documentation](https://github.com/joshuaslate/type-cacheable/tree/main/packages/core)

--- a/packages/node-cache-adapter/lib/index.ts
+++ b/packages/node-cache-adapter/lib/index.ts
@@ -69,7 +69,7 @@ export class NodeCacheAdapter implements CacheClient {
   }
 }
 
-export const useAdapter = (client: NodeCache, asFallback?: boolean): void => {
+export const useAdapter = (client: NodeCache, asFallback?: boolean): NodeCacheAdapter => {
   const nodeCacheAdapter = new NodeCacheAdapter(client);
 
   if (asFallback) {
@@ -77,4 +77,6 @@ export const useAdapter = (client: NodeCache, asFallback?: boolean): void => {
   } else {
     cacheManager.setClient(nodeCacheAdapter);
   }
+
+  return nodeCacheAdapter;
 };

--- a/packages/node-cache-adapter/test/NodeCacheAdapter.test.ts
+++ b/packages/node-cache-adapter/test/NodeCacheAdapter.test.ts
@@ -1,6 +1,6 @@
 import * as NodeCache from 'node-cache';
 import { Cacheable, CacheClear } from '@type-cacheable/core';
-import { NodeCacheAdapter } from '../lib';
+import { NodeCacheAdapter, useAdapter } from '../lib';
 
 let client: NodeCache;
 let nodeCacheAdapter: NodeCacheAdapter;
@@ -16,7 +16,7 @@ const arrayValue = ['element1', 2, { complex: 'element' }];
 describe('NodeCacheAdapter Tests', () => {
   beforeAll(() => {
     client = new NodeCache();
-    nodeCacheAdapter = new NodeCacheAdapter(client);
+    nodeCacheAdapter = useAdapter(client);
   });
 
   describe('Setter tests', () => {

--- a/packages/redis-adapter/README.md
+++ b/packages/redis-adapter/README.md
@@ -25,7 +25,7 @@ import * as Redis from 'redis';
 import { useAdapter } from '@type-cacheable/redis-adapter';
 
 const client = Redis.createClient();
-useAdapter(client);
+const clientAdapter = useAdapter(client);
 ```
 
 Then you can rely on the `@Cacheable`, `@CacheUpdate`, and `@CacheClear` decorators from `@type-cacheable/core`. [See core documentation](https://github.com/joshuaslate/type-cacheable/tree/main/packages/core)

--- a/packages/redis-adapter/lib/index.ts
+++ b/packages/redis-adapter/lib/index.ts
@@ -290,7 +290,7 @@ export class RedisAdapter implements CacheClient {
   }
 }
 
-export const useAdapter = (client: RedisClient, asFallback?: boolean): void => {
+export const useAdapter = (client: RedisClient, asFallback?: boolean): RedisAdapter => {
   const redisAdapter = new RedisAdapter(client);
 
   if (asFallback) {
@@ -298,4 +298,6 @@ export const useAdapter = (client: RedisClient, asFallback?: boolean): void => {
   } else {
     cacheManager.setClient(redisAdapter);
   }
+
+  return redisAdapter;
 };

--- a/packages/redis-adapter/test/RedisAdapter.test.ts
+++ b/packages/redis-adapter/test/RedisAdapter.test.ts
@@ -1,6 +1,6 @@
 import * as Redis from 'redis';
 import { Cacheable, CacheClear } from '@type-cacheable/core';
-import { RedisAdapter } from '../lib';
+import { RedisAdapter, useAdapter } from '../lib';
 
 let client: Redis.RedisClient;
 let redisAdapter: RedisAdapter;
@@ -20,11 +20,11 @@ describe('RedisAdapter Tests', () => {
     // Wait until the connection is ready before passing the client to the adapter.
     await new Promise((resolve) => {
       client.on('ready', () => {
-        resolve();
+        resolve(null);
       });
     });
 
-    redisAdapter = new RedisAdapter(client);
+    redisAdapter = useAdapter(client);
   });
 
   describe('Setter tests', () => {


### PR DESCRIPTION
We use `@Cacheable` to pass the `client` parameter, which would not pass the typescript type check if we used `useAdapter`. Because `useAdapter` returns  void, `@Cacheable` requires the client type to be `CacheClient`.
 
Therefore, I think the `useAdapter` return value should be consistent with `IoRedisAdapter`/`LRUCacheAdapter`/`NodeCacheAdapter`/`RedisAdapter`. When using `useAdapter`, the return value can be provided directly to `@Cacheable`/`@CacheClear`/`@CacheUpdate`