### PR TITLE
Catching client errors

### DIFF
--- a/packages/core/lib/strategies/DefaultStrategy.ts
+++ b/packages/core/lib/strategies/DefaultStrategy.ts
@@ -90,11 +90,14 @@ export class DefaultStrategy implements CacheStrategy {
         resolve(returnValue);
       });
 
-      this.pendingMethodCallMap.set(context.key, methodPromise);
-
-      result = await methodPromise.catch(err => { throw err; });
-
-      this.pendingMethodCallMap.delete(context.key);
+      try {
+        this.pendingMethodCallMap.set(context.key, methodPromise);
+        result = await methodPromise;
+      } catch (err) {
+        throw err;
+      } finally {
+        this.pendingMethodCallMap.delete(context.key);
+      }
     }
 
     return result;


### PR DESCRIPTION
We have the problem, that when our @Cacheable annotated function throws an error, this function never returns and freezes our program. With this PR client errors are catched and returned to the initial caller.