### PR TITLE
Fix: #638 Return date instance if date instance saved to cache.

### DIFF
--- a/packages/redis-adapter/lib/index.ts
+++ b/packages/redis-adapter/lib/index.ts
@@ -10,6 +10,14 @@ const REDIS_VERSION_UNLINK_INTRODUCED = '4.0.0';
 const REDIS_VERSION_FRAGMENT_IDENTIFIER = 'redis_version:';
 const REDIS_SCAN_PAGE_LIMIT = 1000;
 
+const dateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,3}Z$/
+const fixDates = (key: string, value: any) => {
+  if (typeof value === 'string' && dateFormat.test(value)) {
+    return new Date(value)
+  }
+  return value
+}
+
 export class RedisAdapter implements CacheClient {
   static buildSetArgumentsFromObject = (objectValue: any): string[] =>
     Object.keys(objectValue).reduce((accum: any, objectKey: any) => {
@@ -22,14 +30,14 @@ export class RedisAdapter implements CacheClient {
     if (response && typeof response === 'object') {
       return Object.entries(response).reduce((accum: any, curr: any[]) => {
         const [key, value] = curr;
-        accum[key] = JSON.parse(value);
+        accum[key] = JSON.parse(value, fixDates);
 
         return accum;
       }, {});
     }
 
     try {
-      return JSON.parse(response);
+      return JSON.parse(response, fixDates);
     } catch {
       return response;
     }

--- a/packages/redis-adapter/test/RedisAdapter.test.ts
+++ b/packages/redis-adapter/test/RedisAdapter.test.ts
@@ -8,6 +8,7 @@ const compoundKey = 'aCompound:keyForRedis';
 const compoundKeyKeys = 'aCompound:keysForRedis';
 const simpleValue = 'aSimpleValueForRedis';
 const objectValue = { myKeyOne: 'myValOneForRedis' };
+const dateObjectValue = { myDateKey: new Date() };
 const arrayValue = ['element1', 2, { complex: 'elementForRedis' }];
 
 describe('RedisAdapter Tests', () => {
@@ -36,6 +37,14 @@ describe('RedisAdapter Tests', () => {
       const result = await client.get(keyName);
 
       expect(result).toBe(JSON.stringify(objectValue));
+    });
+
+    it('should set an date object value on a standard key', async () => {
+      const keyName = 'aSimpleKey';
+      await redisAdapter.set(keyName, dateObjectValue);
+      const result = await client.get(keyName);
+
+      expect(result).toBe(JSON.stringify(dateObjectValue));
     });
 
     it('should set an array value on a standard key', async () => {
@@ -233,7 +242,7 @@ describe('RedisAdapter Tests', () => {
           async getObjectValue(value: string): Promise<any> {
             mockGetObjectValueImplementation();
 
-            return { hello: 'world', 1: 2, '2': 1, true: false, false: 'true' };
+            return { hello: 'world', 1: 2, '2': 1, true: false, false: 'true', date: new Date('2022-01-02') };
           }
         }
 
@@ -307,6 +316,7 @@ describe('RedisAdapter Tests', () => {
           '2': 1,
           true: false,
           false: 'true',
+          date: new Date('2022-01-02')
         });
         mockGetObjectValueImplementation.mockClear();
 


### PR DESCRIPTION
Should fix date instance caching inconsistency. It is BREAKING for people using this bug as a feature