### PR TITLE
Update lru-cache to 10

### DIFF
--- a/packages/lru-cache-adapter/README.md
+++ b/packages/lru-cache-adapter/README.md
@@ -23,7 +23,7 @@ yarn add @type-cacheable/core @type-cacheable/lru-cache-adapter
 ### Using adapter
 
 ```ts
-import * as LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { useAdapter } from '@type-cacheable/lru-cache-adapter';
 
 const client = new LRUCache();

--- a/packages/lru-cache-adapter/lib/index.ts
+++ b/packages/lru-cache-adapter/lib/index.ts
@@ -1,4 +1,4 @@
-import LRUCache from 'lru-cache';
+import { LRUCache }  from 'lru-cache';
 import cacheManager, { CacheClient } from '@type-cacheable/core';
 
 export class LRUCacheAdapter<T extends {}> implements CacheClient {

--- a/packages/lru-cache-adapter/package.json
+++ b/packages/lru-cache-adapter/package.json
@@ -39,13 +39,12 @@
   "homepage": "https://github.com/joshuaslate/type-cacheable#readme",
   "devDependencies": {
     "@type-cacheable/core": "^12.0.1",
-    "@types/lru-cache": "^7.4.0",
-    "lru-cache": "^8.0.4",
+    "lru-cache": "^10.0.0",
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "@type-cacheable/core": "^12.0.0",
-    "lru-cache": "^8.0.4"
+    "lru-cache": "^10.0.0"
   },
   "gitHead": "ba374530da264bef419e893c8fa44ee2479c7782"
 }

--- a/packages/lru-cache-adapter/test/LRUCacheAdapter.test.ts
+++ b/packages/lru-cache-adapter/test/LRUCacheAdapter.test.ts
@@ -1,4 +1,4 @@
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 import { Cacheable } from '@type-cacheable/core';
 import { LRUCacheAdapter, useAdapter } from '../lib';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,13 +1384,6 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/lru-cache@^7.4.0":
-  version "7.10.10"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.10.10.tgz#3fa937c35ff4b3f6753d5737915c9bf8e693a713"
-  integrity sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==
-  dependencies:
-    lru-cache "*"
-
 "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -3933,10 +3926,10 @@ log-symbols@^4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-lru-cache@*, lru-cache@^8.0.4:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-8.0.5.tgz#983fe337f3e176667f8e567cfcce7cb064ea214e"
-  integrity sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==
+lru-cache@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
 
 lru-cache@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Update lru-cache to 10 with it's own typings and use named export

https://github.com/isaacs/node-lru-cache/blob/main/CHANGELOG.md