### PR TITLE
feat: allow cache client to be loaded from lambda at call time

### DIFF
--- a/packages/core/lib/interfaces/CacheClearOptions.ts
+++ b/packages/core/lib/interfaces/CacheClearOptions.ts
@@ -4,12 +4,13 @@ import { NoOpDeterminer } from './NoOpDeterminer';
 import { CacheKeyDeleteBuilder } from './CacheKeyDeleteBuilder';
 import { CacheClearStrategyBuilder } from './CacheClearStrategyBuilder';
 import { CacheClearStrategy } from './CacheClearStrategy';
+import { CacheClientBuilder } from './CacheClientBuilder';
 
 export interface CacheClearOptions {
   cacheKey?: string | string[] | CacheKeyDeleteBuilder;
   hashKey?: string | CacheKeyBuilder;
-  client?: CacheClient;
-  fallbackClient?: CacheClient;
+  client?: CacheClient | CacheClientBuilder;
+  fallbackClient?: CacheClient | CacheClientBuilder;
   noop?: boolean | NoOpDeterminer;
   isPattern?: boolean;
   strategy?: CacheClearStrategy | CacheClearStrategyBuilder;

--- a/packages/core/lib/interfaces/CacheClientBuilder.ts
+++ b/packages/core/lib/interfaces/CacheClientBuilder.ts
@@ -1,0 +1,5 @@
+import { CacheClient } from "./CacheClient";
+
+export interface CacheClientBuilder<T = any[], U = any> {
+  (args: T, context?: U): CacheClient;
+}

--- a/packages/core/lib/interfaces/CacheOptions.ts
+++ b/packages/core/lib/interfaces/CacheOptions.ts
@@ -1,11 +1,12 @@
 import { CacheKeyBuilder, CacheClient, NoOpDeterminer, TTLBuilder, CacheStrategy, IsCacheableBuilder } from './';
+import { CacheClientBuilder } from './CacheClientBuilder';
 import { CacheStrategyBuilder } from './CacheStrategyBuilder';
 
 export interface CacheOptions {
   cacheKey?: string | CacheKeyBuilder;
   hashKey?: string | CacheKeyBuilder;
-  client?: CacheClient;
-  fallbackClient?: CacheClient;
+  client?: CacheClient | CacheClientBuilder;
+  fallbackClient?: CacheClient | CacheClientBuilder;
   noop?: boolean | NoOpDeterminer;
   ttlSeconds?: number | TTLBuilder;
   strategy?: CacheStrategy | CacheStrategyBuilder;

--- a/packages/core/lib/interfaces/CacheUpdateOptions.ts
+++ b/packages/core/lib/interfaces/CacheUpdateOptions.ts
@@ -8,13 +8,14 @@ import { CacheClearStrategyBuilder } from './CacheClearStrategyBuilder';
 import { PostRunKeyBuilder } from './PostRunKeyBuilder';
 import { CacheUpdateStrategy } from './CacheUpdateStrategy';
 import { CacheUpdateStrategyBuilder } from './CacheUpdateStrategyBuilder';
+import { CacheClientBuilder } from './CacheClientBuilder';
 
 export interface CacheUpdateOptions {
   cacheKey?: string | CacheKeyBuilder | PostRunKeyBuilder;
   cacheKeysToClear?: string | string[] | CacheKeyDeleteBuilder | null;
   hashKey?: string | CacheKeyBuilder | PostRunKeyBuilder;
-  client?: CacheClient;
-  fallbackClient?: CacheClient;
+  client?: CacheClient | CacheClientBuilder;
+  fallbackClient?: CacheClient | CacheClientBuilder;
   noop?: boolean | NoOpDeterminer;
   ttlSeconds?: number | TTLBuilder;
   strategy?: CacheUpdateStrategy | CacheUpdateStrategyBuilder;

--- a/packages/core/lib/interfaces/index.ts
+++ b/packages/core/lib/interfaces/index.ts
@@ -1,6 +1,7 @@
 export { CacheKeyBuilder } from './CacheKeyBuilder';
 export { CacheKeyDeleteBuilder } from './CacheKeyDeleteBuilder';
 export { CacheClient } from './CacheClient';
+export { CacheClientBuilder } from './CacheClientBuilder';
 export { CacheOptions } from './CacheOptions';
 export { CacheClearOptions } from './CacheClearOptions';
 export { CacheManagerOptions } from './CacheManagerOptions';

--- a/packages/core/lib/util/getCacheClient.ts
+++ b/packages/core/lib/util/getCacheClient.ts
@@ -1,0 +1,18 @@
+import { CacheClient, CacheClientBuilder } from '../interfaces';
+
+/**
+ * getCacheClient - Will refine a CacheClient or CacheClientBuilder to a CacheClient
+ *
+ * @param passedInCacheClient A CacheClient, or function to build the CacheClient based on arguments/context
+ * @param args                The arguments the decorated method was called with
+ * @param context             The instance whose method is being called
+ * 
+ * @returns {CacheClient}
+ */
+export const getCacheClient = (passedInCacheClient: CacheClient | CacheClientBuilder, args: any[], context?: any): CacheClient => {
+  // If the user passed in a cacheKey, use that. If it's a string/number, use it directly.
+  // In the case of a function
+  return passedInCacheClient instanceof Function
+    ? passedInCacheClient(args, context)
+    : passedInCacheClient;
+};


### PR DESCRIPTION
Hello there!

I've recently had a use-case that requires loading a custom client for type-cacheable at runtime. I've added support here for fetching the client from a user-defined lambda such that it has the current args and context.

Please let me know if there are any tweaks or issues, happy to update the PR accordingly!