### PR TITLE
chore(typings): useAdapter can use a Redis or Cluster

### DIFF
--- a/packages/ioredis-adapter/lib/index.ts
+++ b/packages/ioredis-adapter/lib/index.ts
@@ -110,7 +110,7 @@ export class IoRedisAdapter implements CacheClient {
   }
 }
 
-export const useAdapter = (client: Redis, asFallback?: boolean, options?: CacheManagerOptions): IoRedisAdapter => {
+export const useAdapter = (client: Redis | Cluster, asFallback?: boolean, options?: CacheManagerOptions): IoRedisAdapter => {
   const ioRedisAdapter = new IoRedisAdapter(client);
 
   if (asFallback) {


### PR DESCRIPTION
I noticed the typings did not allow using a Cluster, but it seems to work. WDYT? 😄